### PR TITLE
fix: 删除rximagepicker_support_wechat模块 app_name

### DIFF
--- a/rximagepicker_support_wechat/src/main/res/values-zh/strings.xml
+++ b/rximagepicker_support_wechat/src/main/res/values-zh/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">rximagepicker_extension_wechat</string>
     <string name="album_name_all">图片和视频</string>
     <string name="send_original">原图</string>
 </resources>

--- a/rximagepicker_support_zhihu/src/main/res/values/strings.xml
+++ b/rximagepicker_support_zhihu/src/main/res/values/strings.xml
@@ -1,3 +1,2 @@
 <resources>
-    <string name="app_name">rximagepicker_support_zhihu</string>
 </resources>


### PR DESCRIPTION
修复引用RxImagePicker依赖库之后导致App名称被覆盖的bug