### PR TITLE
fix: 删除rximagepicker_support_wechat中的app_name

### DIFF
--- a/rximagepicker_support_wechat/src/main/res/values/strings.xml
+++ b/rximagepicker_support_wechat/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">rximagepicker_extension_wechat</string>
     <string name="album_name_all">All Media</string>
     <string name="send_original">Original</string>
 </resources>


### PR DESCRIPTION
之前我提交了3个commit删除了三处，不知道为啥最后request里面只有两个，所以没有删干净，这边补一波